### PR TITLE
Update gpio_handler.py

### DIFF
--- a/mopidy_pummeluff/threads/gpio_handler.py
+++ b/mopidy_pummeluff/threads/gpio_handler.py
@@ -24,11 +24,11 @@ class GPIOHandler(Thread):
     LED when it's started and then reacting to button presses.
     '''
     button_pins = {
-        5: Shutdown,
-        29: PlayPause,
+        37: Shutdown,
+        10: PlayPause,
         31: Stop,
         33: PreviousTrack,
-        35: NextTrack,
+        36: NextTrack,
     }
 
     led_pin = 8


### PR DESCRIPTION
Adjusting used GPIO Pins in GPIO Handler. According to hifiberry documentation for the amp2 shield GPIO 3-5, 4, 18-21 shouldn't be used.